### PR TITLE
Replace git commit with S3 upload in CI workflow

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   generate:
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ${{ secrets.S3_REGION }}
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
@@ -14,12 +18,8 @@ jobs:
         with:
           node-version: 16.x
       - run: npm i
+      - name: Download existing data from S3
+        run: aws s3 sync "s3://${{ secrets.S3_BUCKET }}/data" ./data --endpoint-url "${{ secrets.S3_ENDPOINT }}" || true
       - run: node --max_old_space_size=4096 placecompile crawl --output=file
-      - name: Commit & Push
-        uses: actions-x/commit@v2
-        with:
-          email: noreply@rrainn.com
-          name: GitHub Actions
-          branch: main
-          files: data
-          message: 'Updating data'
+      - name: Upload data to S3
+        run: aws s3 sync ./data "s3://${{ secrets.S3_BUCKET }}/data" --endpoint-url "${{ secrets.S3_ENDPOINT }}" --exclude ".gitkeep"


### PR DESCRIPTION
The crawl workflow currently commits data files directly to the `main` branch via `actions-x/commit`. This couples data storage to the git repository and bloats the repo over time. This PR switches to uploading the generated data files to an S3-compatible endpoint instead.

## Approach

The workflow now has two new S3 steps bracketing the crawl:

1. **Download existing data from S3** (before crawl) — pulls the last known-good data files into `./data` so that if any spider fails during the crawl, its previous output is preserved.
2. **Upload data to S3** (after crawl) — syncs `./data` back to the bucket, overwriting only the files that were successfully regenerated.

The `actions-x/commit` step is removed entirely.

## Configuration

All S3 settings are read from GitHub Actions secrets:

| Secret | Purpose |
|---|---|
| `S3_ACCESS_KEY_ID` | Access key |
| `S3_SECRET_ACCESS_KEY` | Secret key |
| `S3_REGION` | Region (e.g. `us-east-1`, `auto`) |
| `S3_BUCKET` | Bucket name |
| `S3_ENDPOINT` | Full endpoint URL for the S3-compatible service |

## Notes

- The download step uses `|| true` so the first run (empty bucket) doesn't fail the workflow.
- `.gitkeep` is excluded from the S3 upload.
- No versioning — files are overwritten each run, as requested.